### PR TITLE
Type customization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4

--- a/src/docstrands/__init__.py
+++ b/src/docstrands/__init__.py
@@ -1,3 +1,2 @@
-from docstrands.parsed_func import docstring, ParsedFunc, Description, TypeDescription
-
-__all__ = ["docstring", "ParsedFunc", "Description", "TypeDescription"]
+from docstrands.parsed_func import docstring
+from docstrands.annotations import Description, TypeDescription

--- a/src/docstrands/__init__.py
+++ b/src/docstrands/__init__.py
@@ -1,2 +1,8 @@
 from docstrands.parsed_func import docstring
 from docstrands.annotations import Description, TypeDescription
+
+__all__ = [
+    "docstring",
+    "Description",
+    "TypeDescription",
+]

--- a/src/docstrands/__init__.py
+++ b/src/docstrands/__init__.py
@@ -1,3 +1,3 @@
-from docstrands.parsed_func import docstring, ParsedFunc, Description
+from docstrands.parsed_func import docstring, ParsedFunc, Description, TypeDescription
 
-__all__ = ["docstring", "ParsedFunc", "Description"]
+__all__ = ["docstring", "ParsedFunc", "Description", "TypeDescription"]

--- a/src/docstrands/annotations.py
+++ b/src/docstrands/annotations.py
@@ -6,11 +6,14 @@ class Description:
     """
     Allows a description to be attached to any type annotation.
     """
+
     description: str
+
 
 @dataclass
 class TypeDescription:
     """
     Annotation that can be used to customize how a given type annotation is displayed in the help and in generated documentation.
     """
+
     description: str

--- a/src/docstrands/annotations.py
+++ b/src/docstrands/annotations.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Description:
+    """
+    Allows a description to be attached to any type annotation.
+    """
+    description: str
+
+@dataclass
+class TypeDescription:
+    """
+    Annotation that can be used to customize how a given type annotation is displayed in the help and in generated documentation.
+    """
+    description: str

--- a/src/docstrands/merge.py
+++ b/src/docstrands/merge.py
@@ -2,6 +2,7 @@ import inspect
 from typing import Any, Callable, TypeVar
 from docstring_parser import Docstring, DocstringParam, DocstringReturns
 
+
 def merge_strs(left: str | None, right: str | None) -> str | None:
     """
     Chooses the most informative string, prioritising the right if there is a tie
@@ -9,7 +10,9 @@ def merge_strs(left: str | None, right: str | None) -> str | None:
     # Any None or "" loses to any full string
     return sorted([left, right], key=bool, reverse=True)[0]
 
+
 T = TypeVar("T", DocstringParam, DocstringReturns)
+
 
 def merge_meta(left: T | None, right: T | None) -> T:
     match (left, right):
@@ -26,32 +29,35 @@ def merge_meta(left: T | None, right: T | None) -> T:
                 default=merge_strs(left.default, right.default),
                 is_optional=left.is_optional or right.is_optional,
                 args=["param", left.arg_name],
-                type_name=merge_strs(left.type_name, right.type_name)
+                type_name=merge_strs(left.type_name, right.type_name),
             )
         case DocstringReturns(), DocstringReturns():
             return DocstringReturns(
                 description=merge_strs(left.description, right.description),
                 args=[],
                 type_name=merge_strs(left.type_name, right.type_name),
-                is_generator=left.is_generator or right.is_generator
+                is_generator=left.is_generator or right.is_generator,
             )
         case (_, _):
             raise ValueError("Cannot merge different types of DocstringMeta objects")
 
 
-def merge_docstrings(func: Callable[..., Any], left: Docstring, right: Docstring) -> Docstring:
+def merge_docstrings(
+    func: Callable[..., Any], left: Docstring, right: Docstring
+) -> Docstring:
     """
     Merges two docstrings, preferring the right docstring in case of conflicts.
     """
     signature = inspect.signature(func)
 
     merged = Docstring()
-    merged.short_description = merge_strs(left.short_description, right.short_description)
+    merged.short_description = merge_strs(
+        left.short_description, right.short_description
+    )
     merged.long_description = merge_strs(left.long_description, right.long_description)
     merged.blank_after_long_description = right.blank_after_long_description
     merged.blank_after_short_description = right.blank_after_short_description
     merged.style = right.style
-
 
     # Merge parameters
     for name in signature.parameters.keys():
@@ -64,6 +70,12 @@ def merge_docstrings(func: Callable[..., Any], left: Docstring, right: Docstring
     merged.meta.append(merge_meta(left.returns, right.returns))
 
     # Other misc metadata
-    merged.meta.extend([meta for meta in left.meta + right.meta if not isinstance(meta, (DocstringParam, DocstringReturns))])
+    merged.meta.extend(
+        [
+            meta
+            for meta in left.meta + right.meta
+            if not isinstance(meta, (DocstringParam, DocstringReturns))
+        ]
+    )
 
     return merged

--- a/src/docstrands/merge.py
+++ b/src/docstrands/merge.py
@@ -1,0 +1,69 @@
+import inspect
+from typing import Any, Callable, TypeVar
+from docstring_parser import Docstring, DocstringParam, DocstringReturns
+
+def merge_strs(left: str | None, right: str | None) -> str | None:
+    """
+    Chooses the most informative string, prioritising the right if there is a tie
+    """
+    # Any None or "" loses to any full string
+    return sorted([left, right], key=bool, reverse=True)[0]
+
+T = TypeVar("T", DocstringParam, DocstringReturns)
+
+def merge_meta(left: T | None, right: T | None) -> T:
+    match (left, right):
+        case (None, None):
+            raise ValueError("Cannot merge two None DocstringMeta objects")
+        case (None, right):
+            return right
+        case (left, None):
+            return left
+        case DocstringParam(), DocstringParam():
+            return DocstringParam(
+                arg_name=left.arg_name,
+                description=merge_strs(left.description, right.description),
+                default=merge_strs(left.default, right.default),
+                is_optional=left.is_optional or right.is_optional,
+                args=["param", left.arg_name],
+                type_name=merge_strs(left.type_name, right.type_name)
+            )
+        case DocstringReturns(), DocstringReturns():
+            return DocstringReturns(
+                description=merge_strs(left.description, right.description),
+                args=[],
+                type_name=merge_strs(left.type_name, right.type_name),
+                is_generator=left.is_generator or right.is_generator
+            )
+        case (_, _):
+            raise ValueError("Cannot merge different types of DocstringMeta objects")
+
+
+def merge_docstrings(func: Callable[..., Any], left: Docstring, right: Docstring) -> Docstring:
+    """
+    Merges two docstrings, preferring the right docstring in case of conflicts.
+    """
+    signature = inspect.signature(func)
+
+    merged = Docstring()
+    merged.short_description = merge_strs(left.short_description, right.short_description)
+    merged.long_description = merge_strs(left.long_description, right.long_description)
+    merged.blank_after_long_description = right.blank_after_long_description
+    merged.blank_after_short_description = right.blank_after_short_description
+    merged.style = right.style
+
+
+    # Merge parameters
+    for name in signature.parameters.keys():
+        left_param = next((p for p in left.params if p.arg_name == name), None)
+        right_param = next((p for p in right.params if p.arg_name == name), None)
+        merged_param = merge_meta(left_param, right_param)
+        merged.meta.append(merged_param)
+
+    # Merge returns
+    merged.meta.append(merge_meta(left.returns, right.returns))
+
+    # Other misc metadata
+    merged.meta.extend([meta for meta in left.meta + right.meta if not isinstance(meta, (DocstringParam, DocstringReturns))])
+
+    return merged

--- a/src/docstrands/parsed_func.py
+++ b/src/docstrands/parsed_func.py
@@ -123,11 +123,7 @@ class ParsedFunc(Generic[P, R]):
             if self.docstring.returns is None:
                 raise ValueError("No return documentation to copy.")
             # Remove any existing return documentation
-            new_docstring.meta = list(
-                filter(
-                    lambda x: not isinstance(x, DocstringReturns), new_docstring.meta
-                )
-            )
+            new_docstring.meta = [x for x in new_docstring.meta if not isinstance(x, DocstringReturns)]
             # Add the new return documentation
             new_docstring.meta.append(self.docstring.returns)
             return ParsedFunc(other.func, new_docstring)

--- a/src/docstrands/parsed_func.py
+++ b/src/docstrands/parsed_func.py
@@ -5,7 +5,7 @@ from typing_extensions import ParamSpec
 from docstring_parser import DocstringParam, parse, DocstringStyle as StyleEnum, Docstring, compose, DocstringReturns, RenderingStyle
 from copy import copy
 
-from docstrands.annotations import Description
+from docstrands.annotations import Description, TypeDescription
 
 AnyFunc = Callable[..., Any]
 T = TypeVar("T", bound=AnyFunc)
@@ -32,6 +32,20 @@ STYLE_MAP: dict[DocstringStyle, StyleEnum] = {
     "epydoc": StyleEnum.EPYDOC,
     "auto": StyleEnum.AUTO,
 }
+
+def get_param(doc: Docstring, param_name: str) -> DocstringParam | None:
+    """
+    Returns an existing parameter definition
+    """
+    for param in doc.params:
+        if param_name == param.arg_name:
+            return param
+
+def delete_param(doc: Docstring, param_name: str):
+    """
+    Deletes any parameters with the given name
+    """
+    doc.meta = [meta for meta in doc.meta if not (isinstance(meta, DocstringParam) and meta.arg_name == param_name)]
 
 @dataclass
 class ParsedFunc(Generic[P, R]):
@@ -81,6 +95,8 @@ class ParsedFunc(Generic[P, R]):
             new_docstring = copy(other.docstring)
             for param in self.docstring.params:
                 if param.arg_name in params:
+                    # Delete any existing parameter descriptions with this name
+                    delete_param(new_docstring, param.arg_name)
                     new_docstring.meta.append(param)
             return replace(
                 other,
@@ -152,9 +168,22 @@ class ParsedFunc(Generic[P, R]):
                 self.docstring.meta.append(DocstringReturns(args=["returns"], description=ret_description, type_name=extract_typename(ret_type), return_name=None, is_generator=False))
         for param_name, param_type in signature.items():
             param_description = extract_description(param_type)
-            if param_description is not None:
-                # args=["param", param_name] seems to be used by all DocstringParam
-                self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=extract_typename(param_type), arg_name=param_name, description=param_description, is_optional=False, default=None))
+            type_name = extract_typename(param_type)
+
+            # The parameter we are describing via annotations might already exist in the docstring
+            if (existing_param := get_param(self.docstring, param_name)) is None:
+                # If it doesn't exist, we create a new one
+                # args=["param", param_name] seems to the correct args for DocstringParam
+                self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=type_name, arg_name=param_name, description=param_description, is_optional=False, default=None))
+            else:
+                # Update the type only if we had no existing description for it, 
+                # because what we `type_name` is not guaranteed to be informative
+                if existing_param.type_name is None:
+                    existing_param.type_name = type_name
+                # Update the description if we find any Description,
+                # this is likely to be more informative
+                if param_description is not None:
+                    existing_param.description = param_description
 
 
 def extract_description(typ: Any) -> str | None:
@@ -168,6 +197,9 @@ def extract_typename(type: Any) -> str:
     Strips out any annotations, and returns the name of the type as a string
     """
     if get_origin(type) == Annotated:
+        for annotation in get_args(type):
+            if isinstance(annotation, TypeDescription):
+                return annotation.description
         # Strip away annotations
         type = get_args(type)[0]
     return getattr(type, "__name__", str(type))

--- a/src/docstrands/parsed_func.py
+++ b/src/docstrands/parsed_func.py
@@ -173,7 +173,7 @@ class ParsedFunc(Generic[P, R]):
             # The parameter we are describing via annotations might already exist in the docstring
             if (existing_param := get_param(self.docstring, param_name)) is None:
                 # If it doesn't exist, we create a new one
-                # args=["param", param_name] seems to the correct args for DocstringParam
+                # args=["param", param_name] seems to be the correct args for DocstringParam
                 self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=type_name, arg_name=param_name, description=param_description, is_optional=False, default=None))
             else:
                 # Update the type only if we had no existing description for it, 

--- a/src/docstrands/parsed_func.py
+++ b/src/docstrands/parsed_func.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace
-from typing import Annotated, Callable, Literal, Any, Generic, TypeVar, get_args, get_origin, get_type_hints
+from typing import Callable, Literal, Any, Generic, TypeVar
 from typing_extensions import ParamSpec
-from docstring_parser import DocstringParam, parse, DocstringStyle as StyleEnum, Docstring, compose, DocstringReturns, RenderingStyle
+from docstring_parser import parse, DocstringStyle as StyleEnum, Docstring, compose, DocstringReturns, RenderingStyle
+from docstrands.parser_utils import delete_param
 from copy import copy
+from docstrands.signature import docstring_from_signature
+from docstrands.merge import merge_docstrings
 
-from docstrands.annotations import Description, TypeDescription
 
 AnyFunc = Callable[..., Any]
 T = TypeVar("T", bound=AnyFunc)
@@ -33,20 +35,6 @@ STYLE_MAP: dict[DocstringStyle, StyleEnum] = {
     "auto": StyleEnum.AUTO,
 }
 
-def get_param(doc: Docstring, param_name: str) -> DocstringParam | None:
-    """
-    Returns an existing parameter definition
-    """
-    for param in doc.params:
-        if param_name == param.arg_name:
-            return param
-
-def delete_param(doc: Docstring, param_name: str):
-    """
-    Deletes any parameters with the given name
-    """
-    doc.meta = [meta for meta in doc.meta if not (isinstance(meta, DocstringParam) and meta.arg_name == param_name)]
-
 @dataclass
 class ParsedFunc(Generic[P, R]):
     """
@@ -59,6 +47,14 @@ class ParsedFunc(Generic[P, R]):
     "The original function."
     docstring: Docstring
     "The parsed docstring."
+
+    @classmethod
+    def parse(cls, func: Callable[P, R], style: DocstringStyle = "auto") -> ParsedFunc[P, R]:
+        _style = STYLE_MAP[style]
+        return cls(
+            func=func,
+            docstring=parse(func.__doc__ or "", style=_style)
+        )
 
     def __repr__(self) -> str:
         # This shows up in the help, where we want it to impersonate the original function
@@ -118,7 +114,7 @@ class ParsedFunc(Generic[P, R]):
             new_docstring.meta.append(self.docstring.returns)
             return ParsedFunc(
                 other.func,
-                new_docstring,
+                new_docstring
             )
         return decorator
 
@@ -133,7 +129,7 @@ class ParsedFunc(Generic[P, R]):
             new_docstring.short_description = self.docstring.short_description
             return ParsedFunc(
                 other.func,
-                new_docstring,
+                new_docstring
             )
         return decorator
 
@@ -148,58 +144,27 @@ class ParsedFunc(Generic[P, R]):
             new_docstring.long_description = self.docstring.long_description
             return ParsedFunc(
                 other.func,
-                new_docstring,
+                new_docstring
             )
         return decorator
 
     def apply_annotations(self) -> None:
-        try:
-            signature = get_type_hints(self.func, include_extras=True)
-            # TODO: Use self.func.__annotations__ to parse out the type without evaluating it
-        except TypeError as e:
-            raise TypeError(f"Error when evaluating the type signature for {self.func.__name__}. Consider using a newer Python version") from e
-        if (ret_type := signature.pop("return", None)) is not None and (ret_description := extract_description(ret_type)) is not None:
-            # Remove any existing return documentation
-            self.docstring.meta = list(filter(lambda x: not isinstance(x, DocstringReturns), self.docstring.meta))
-            # args=["returns"] seems to be used by all DocstringReturns
-            self.docstring.meta.append(DocstringReturns(args=["returns"], description=ret_description, type_name=extract_typename(ret_type), return_name=None, is_generator=False))
-        for param_name, param_type in signature.items():
-            param_description = extract_description(param_type)
-            type_name = extract_typename(param_type)
+        pseudo_docstring = docstring_from_signature(self.func)
+        self.docstring = merge_docstrings(self.func, pseudo_docstring, self.docstring)
 
-            # The parameter we are describing via annotations might already exist in the docstring
-            if (existing_param := get_param(self.docstring, param_name)) is None:
-                # If it doesn't exist, we create a new one
-                # args=["param", param_name] seems to be the correct args for DocstringParam
-                self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=type_name, arg_name=param_name, description=param_description, is_optional=False, default=None))
-            else:
-                # Update the type only if we had no existing description for it, 
-                # because what we `type_name` is not guaranteed to be informative
-                if existing_param.type_name is None:
-                    existing_param.type_name = type_name
-                # Update the description if we find any Description,
-                # this is likely to be more informative
-                if param_description is not None:
-                    existing_param.description = param_description
-
-
-def extract_description(typ: Any) -> str | None:
-    if get_origin(typ) is Annotated:
-        for annotation in get_args(typ):
-            if isinstance(annotation, Description):
-                return annotation.description
-
-def extract_typename(type: Any) -> str:
-    """
-    Strips out any annotations, and returns the name of the type as a string
-    """
-    if get_origin(type) == Annotated:
-        for annotation in get_args(type):
-            if isinstance(annotation, TypeDescription):
-                return annotation.description
-        # Strip away annotations
-        type = get_args(type)[0]
-    return getattr(type, "__name__", str(type))
+            # if (existing_param := get_param(self.docstring, param_name)) is None:
+            #     # If it doesn't exist, we create a new one
+            #     # args=["param", param_name] seems to be the correct args for DocstringParam
+            #     self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=type_name, arg_name=param_name, description=param_description, is_optional=False, default=None))
+            # else:
+            #     # Update the type only if we had no existing description for it, 
+            #     # because what we `type_name` is not guaranteed to be informative
+            #     if existing_param.type_name is None:
+            #         existing_param.type_name = type_name
+            #     # Update the description if we find any Description,
+            #     # this is likely to be more informative
+            #     if param_description is not None:
+            #         existing_param.description = param_description
 
 
 def docstring(style: DocstringStyle, use_annotations: bool = True) -> Callable[[Callable[P, R]], ParsedFunc[P, R]]:
@@ -214,7 +179,7 @@ def docstring(style: DocstringStyle, use_annotations: bool = True) -> Callable[[
         A decorator. When this is applied to a function this decorator will return a [`ParsedFunc`][docstrands.ParsedFunc] object.
     """
     def decorator(func: Callable[P, R]) -> ParsedFunc[P, R]:
-        ret: ParsedFunc[P, R] = ParsedFunc(func, parse(func.__doc__ or "", STYLE_MAP[style]))
+        ret: ParsedFunc[P, R] = ParsedFunc.parse(func, style)
         if use_annotations:
             ret.apply_annotations()
         return ret

--- a/src/docstrands/parsed_func.py
+++ b/src/docstrands/parsed_func.py
@@ -166,20 +166,6 @@ class ParsedFunc(Generic[P, R]):
         pseudo_docstring = docstring_from_signature(self.func)
         self.docstring = merge_docstrings(self.func, pseudo_docstring, self.docstring)
 
-        # if (existing_param := get_param(self.docstring, param_name)) is None:
-        #     # If it doesn't exist, we create a new one
-        #     # args=["param", param_name] seems to be the correct args for DocstringParam
-        #     self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=type_name, arg_name=param_name, description=param_description, is_optional=False, default=None))
-        # else:
-        #     # Update the type only if we had no existing description for it,
-        #     # because what we `type_name` is not guaranteed to be informative
-        #     if existing_param.type_name is None:
-        #         existing_param.type_name = type_name
-        #     # Update the description if we find any Description,
-        #     # this is likely to be more informative
-        #     if param_description is not None:
-        #         existing_param.description = param_description
-
 
 def docstring(
     style: DocstringStyle, use_annotations: bool = True

--- a/src/docstrands/parsed_func.py
+++ b/src/docstrands/parsed_func.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import Callable, Literal, Any, Generic, TypeVar
 from typing_extensions import ParamSpec
-from docstring_parser import parse, DocstringStyle as StyleEnum, Docstring, compose, DocstringReturns, RenderingStyle
+from docstring_parser import (
+    parse,
+    DocstringStyle as StyleEnum,
+    Docstring,
+    compose,
+    DocstringReturns,
+    RenderingStyle,
+)
 from docstrands.parser_utils import delete_param
 from copy import copy
 from docstrands.signature import docstring_from_signature
@@ -35,6 +42,7 @@ STYLE_MAP: dict[DocstringStyle, StyleEnum] = {
     "auto": StyleEnum.AUTO,
 }
 
+
 @dataclass
 class ParsedFunc(Generic[P, R]):
     """
@@ -43,23 +51,23 @@ class ParsedFunc(Generic[P, R]):
     In general `ParsedFunc` impersonates the original function, so it can be used in most places where the original function would be used.
     A `ParsedFunc` should only ever be created by the `docstring` decorator.
     """
+
     func: AnyFunc
     "The original function."
     docstring: Docstring
     "The parsed docstring."
 
     @classmethod
-    def parse(cls, func: Callable[P, R], style: DocstringStyle = "auto") -> ParsedFunc[P, R]:
+    def parse(
+        cls, func: Callable[P, R], style: DocstringStyle = "auto"
+    ) -> ParsedFunc[P, R]:
         _style = STYLE_MAP[style]
-        return cls(
-            func=func,
-            docstring=parse(func.__doc__ or "", style=_style)
-        )
+        return cls(func=func, docstring=parse(func.__doc__ or "", style=_style))
 
     def __repr__(self) -> str:
         # This shows up in the help, where we want it to impersonate the original function
         return repr(self.func)
-    
+
     def __str__(self) -> str:
         # This shows up in the help, where we want it to impersonate the original function
         return str(self.func)
@@ -78,15 +86,22 @@ class ParsedFunc(Generic[P, R]):
         if self.docstring.style is None:
             return self.func.__doc__
         else:
-            return compose(self.docstring, self.docstring.style, rendering_style=RenderingStyle.CLEAN)
+            return compose(
+                self.docstring,
+                self.docstring.style,
+                rendering_style=RenderingStyle.CLEAN,
+            )
 
-    def copy_params(self, *params: str) -> Callable[[ParsedFunc[Q, S]], ParsedFunc[Q, S]]:
+    def copy_params(
+        self, *params: str
+    ) -> Callable[[ParsedFunc[Q, S]], ParsedFunc[Q, S]]:
         """
         Copies parameter documentation from this function to the decorated function.
 
         Params:
             params: The names of the parameters to copy.
         """
+
         def decorator(other: ParsedFunc[Q, S]) -> ParsedFunc[Q, S]:
             new_docstring = copy(other.docstring)
             for param in self.docstring.params:
@@ -94,80 +109,81 @@ class ParsedFunc(Generic[P, R]):
                     # Delete any existing parameter descriptions with this name
                     delete_param(new_docstring, param.arg_name)
                     new_docstring.meta.append(param)
-            return replace(
-                other,
-                docstring=new_docstring
-            )
+            return replace(other, docstring=new_docstring)
+
         return decorator
 
     def copy_returns(self) -> Callable[[ParsedFunc[Q, S]], ParsedFunc[Q, S]]:
         """
         Copies the return documentation from this function to the decorated function.
         """
+
         def decorator(other: ParsedFunc[Q, S]) -> ParsedFunc[Q, S]:
             new_docstring = copy(other.docstring)
             if self.docstring.returns is None:
                 raise ValueError("No return documentation to copy.")
             # Remove any existing return documentation
-            new_docstring.meta = list(filter(lambda x: not isinstance(x, DocstringReturns), new_docstring.meta))
+            new_docstring.meta = list(
+                filter(
+                    lambda x: not isinstance(x, DocstringReturns), new_docstring.meta
+                )
+            )
             # Add the new return documentation
             new_docstring.meta.append(self.docstring.returns)
-            return ParsedFunc(
-                other.func,
-                new_docstring
-            )
+            return ParsedFunc(other.func, new_docstring)
+
         return decorator
 
     def copy_synopsis(self) -> Callable[[ParsedFunc[Q, S]], ParsedFunc[Q, S]]:
         """
         Copies the synopsis (first line) from this function to the decorated function.
         """
+
         def decorator(other: ParsedFunc[Q, S]) -> ParsedFunc[Q, S]:
             new_docstring = copy(other.docstring)
             if self.docstring.short_description is None:
                 raise ValueError("No synopsis to copy.")
             new_docstring.short_description = self.docstring.short_description
-            return ParsedFunc(
-                other.func,
-                new_docstring
-            )
+            return ParsedFunc(other.func, new_docstring)
+
         return decorator
 
     def copy_description(self) -> Callable[[ParsedFunc[Q, S]], ParsedFunc[Q, S]]:
         """
         Copies the description (everything after the synopsis that isn't in a dedicated block) from this function to the decorated function.
         """
+
         def decorator(other: ParsedFunc[Q, S]) -> ParsedFunc[Q, S]:
             new_docstring = copy(other.docstring)
             if self.docstring.long_description is None:
                 raise ValueError("No description to copy.")
             new_docstring.long_description = self.docstring.long_description
-            return ParsedFunc(
-                other.func,
-                new_docstring
-            )
+            return ParsedFunc(other.func, new_docstring)
+
         return decorator
 
     def apply_annotations(self) -> None:
         pseudo_docstring = docstring_from_signature(self.func)
         self.docstring = merge_docstrings(self.func, pseudo_docstring, self.docstring)
 
-            # if (existing_param := get_param(self.docstring, param_name)) is None:
-            #     # If it doesn't exist, we create a new one
-            #     # args=["param", param_name] seems to be the correct args for DocstringParam
-            #     self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=type_name, arg_name=param_name, description=param_description, is_optional=False, default=None))
-            # else:
-            #     # Update the type only if we had no existing description for it, 
-            #     # because what we `type_name` is not guaranteed to be informative
-            #     if existing_param.type_name is None:
-            #         existing_param.type_name = type_name
-            #     # Update the description if we find any Description,
-            #     # this is likely to be more informative
-            #     if param_description is not None:
-            #         existing_param.description = param_description
+        # if (existing_param := get_param(self.docstring, param_name)) is None:
+        #     # If it doesn't exist, we create a new one
+        #     # args=["param", param_name] seems to be the correct args for DocstringParam
+        #     self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=type_name, arg_name=param_name, description=param_description, is_optional=False, default=None))
+        # else:
+        #     # Update the type only if we had no existing description for it,
+        #     # because what we `type_name` is not guaranteed to be informative
+        #     if existing_param.type_name is None:
+        #         existing_param.type_name = type_name
+        #     # Update the description if we find any Description,
+        #     # this is likely to be more informative
+        #     if param_description is not None:
+        #         existing_param.description = param_description
 
 
-def docstring(style: DocstringStyle, use_annotations: bool = True) -> Callable[[Callable[P, R]], ParsedFunc[P, R]]:
+def docstring(
+    style: DocstringStyle, use_annotations: bool = True
+) -> Callable[[Callable[P, R]], ParsedFunc[P, R]]:
     """
     Parses the docstring of a function so that it can be manipulated.
 
@@ -178,10 +194,11 @@ def docstring(style: DocstringStyle, use_annotations: bool = True) -> Callable[[
     Returns:
         A decorator. When this is applied to a function this decorator will return a [`ParsedFunc`][docstrands.ParsedFunc] object.
     """
+
     def decorator(func: Callable[P, R]) -> ParsedFunc[P, R]:
         ret: ParsedFunc[P, R] = ParsedFunc.parse(func, style)
         if use_annotations:
             ret.apply_annotations()
         return ret
-    return decorator
 
+    return decorator

--- a/src/docstrands/parsed_func.py
+++ b/src/docstrands/parsed_func.py
@@ -5,6 +5,8 @@ from typing_extensions import ParamSpec
 from docstring_parser import DocstringParam, parse, DocstringStyle as StyleEnum, Docstring, compose, DocstringReturns, RenderingStyle
 from copy import copy
 
+from docstrands.annotations import Description
+
 AnyFunc = Callable[..., Any]
 T = TypeVar("T", bound=AnyFunc)
 
@@ -150,13 +152,6 @@ class ParsedFunc(Generic[P, R]):
                 # args=["param", param_name] seems to be used by all DocstringParam
                 self.docstring.meta.append(DocstringParam(args=["param", param_name], type_name=None, arg_name=param_name, description=param_description, is_optional=False, default=None))
 
-
-@dataclass
-class Description:
-    """
-    Allows a description to be attached to any type annotation.
-    """
-    description: str
 
 def extract_description(typ: Any) -> str | None:
     if get_origin(typ) is Annotated:

--- a/src/docstrands/parser_utils.py
+++ b/src/docstrands/parser_utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions that apply to docstring_parser types
 """
+
 from docstring_parser import Docstring, DocstringParam
 
 
@@ -13,6 +14,7 @@ def find_param(doc: Docstring, param_name: str) -> int | None:
             return i
     return None
 
+
 def get_param(doc: Docstring, param_name: str) -> DocstringParam | None:
     """
     Returns an existing parameter definition
@@ -20,11 +22,17 @@ def get_param(doc: Docstring, param_name: str) -> DocstringParam | None:
     i = find_param(doc, param_name)
     return doc.params[i] if i is not None else None
 
+
 def delete_param(doc: Docstring, param_name: str):
     """
     Deletes any parameters with the given name
     """
-    doc.meta = [meta for meta in doc.meta if not (isinstance(meta, DocstringParam) and meta.arg_name == param_name)]
+    doc.meta = [
+        meta
+        for meta in doc.meta
+        if not (isinstance(meta, DocstringParam) and meta.arg_name == param_name)
+    ]
+
 
 def add_param(doc: Docstring, param: DocstringParam):
     """

--- a/src/docstrands/parser_utils.py
+++ b/src/docstrands/parser_utils.py
@@ -1,0 +1,38 @@
+"""
+Utility functions that apply to docstring_parser types
+"""
+from docstring_parser import Docstring, DocstringParam
+
+
+def find_param(doc: Docstring, param_name: str) -> int | None:
+    """
+    Returns the index of the parameter with the given name, or None if it does not exist
+    """
+    for i, param in enumerate(doc.params):
+        if param_name == param.arg_name:
+            return i
+    return None
+
+def get_param(doc: Docstring, param_name: str) -> DocstringParam | None:
+    """
+    Returns an existing parameter definition
+    """
+    i = find_param(doc, param_name)
+    return doc.params[i] if i is not None else None
+
+def delete_param(doc: Docstring, param_name: str):
+    """
+    Deletes any parameters with the given name
+    """
+    doc.meta = [meta for meta in doc.meta if not (isinstance(meta, DocstringParam) and meta.arg_name == param_name)]
+
+def add_param(doc: Docstring, param: DocstringParam):
+    """
+    Adds a parameter to the docstring.
+    If an existing parameter with the same name exists, it replaces it in the same position
+    """
+    i = find_param(doc, param.arg_name)
+    if i is not None:
+        doc.params[i] = param
+    else:
+        doc.params.append(param)

--- a/src/docstrands/signature.py
+++ b/src/docstrands/signature.py
@@ -95,14 +95,16 @@ def docstring_from_signature(func: Callable[..., Any]) -> Docstring:
         )
 
     ret_description, ret_type = parse_uneval_type(parsed.returns)
-    doc.meta.append(
-        DocstringReturns(
-            type_name=ret_type,
-            description=ret_description,
-            is_generator=inspect.isgeneratorfunction(func),
-            return_name=None,
-            args=[],
+    if ret_type is not None or ret_description is not None:
+        # Adding a completely empty DocstringReturns is not useful
+        doc.meta.append(
+            DocstringReturns(
+                type_name=ret_type,
+                description=ret_description,
+                is_generator=inspect.isgeneratorfunction(func),
+                return_name=None,
+                args=[],
+            )
         )
-    )
 
     return doc

--- a/src/docstrands/signature.py
+++ b/src/docstrands/signature.py
@@ -1,132 +1,100 @@
 """
 Utilities for extracting type information by inspecting functions rather than parsing docstrings.
 """
+
 from __future__ import annotations
-from typing import Callable, Any
+from itertools import zip_longest
+from textwrap import dedent
+from typing import Callable, Any, Iterable
 from docstring_parser import Docstring, DocstringParam, DocstringReturns
-from typing import (
-    Annotated,
-    Callable,
-    Any,
-    get_args,
-    get_origin,
-)
-from docstring_parser import (
-    DocstringParam,
-    Docstring,
-    DocstringReturns,
-)
 import inspect
 import ast
 
 from docstrands.annotations import Description, TypeDescription
 
-def extract_description(typ: str) -> str | None:
-    """
-    Extracts the description from a type signature provided as a string.
-    """
-    if get_origin(typ) is Annotated:
-        for annotation in get_args(typ):
-            if isinstance(annotation, Description):
-                return annotation.description
 
-def parse_uneval_type(typ: str) -> tuple[str | None, str]:
+def parse_uneval_type(typ: ast.expr | None) -> tuple[str | None, str | None]:
     """
     Given an unevaluated type signature as a string, returns a tuple of (value description, type signature).
     This does not evaluate the type, meaning that Python version is not important.
     """
-    parsed: ast.expr = ast.parse(typ, mode="eval").body
+    if typ is None:
+        return None, None
+
     description: str | None = None
-    type_name = typ
+    type_name = ast.unparse(typ)
     # Peel away any number of Annotated until we reach the inner type
     while True:
-        match parsed:
+        match typ:
             case ast.Subscript(
                 value=ast.Name(id="Annotated"),
-                slice=ast.Tuple(elts=[parsed, *annotations]),
+                slice=ast.Tuple(elts=[typ, *annotations]),
             ):
                 # Peel away the Annotated type each iteration
-                type_name: str = ast.unparse(parsed)
+                type_name: str = ast.unparse(typ)
                 for annotation in annotations:
                     # If we find a Description or TypeDescription, we update the return value
-                    compiled = compile(ast.Expression(annotation), filename="<ast>", mode="eval")
+                    compiled = compile(
+                        ast.Expression(annotation), filename="<ast>", mode="eval"
+                    )
                     result = eval(compiled)
                     if isinstance(result, Description):
                         description = result.description
                     elif isinstance(result, TypeDescription):
                         type_name = result.description
-            case ast.Constant():
+            case ast.Constant(value=str()):
                 # Evaluate types expressed as strings
-                compiled = compile(ast.Expression(parsed), filename="<ast>", mode="eval")
+                compiled = compile(ast.Expression(typ), filename="<ast>", mode="eval")
                 result = type_name = eval(compiled)
-                parsed = ast.parse(result, mode="eval").body
+                typ = ast.parse(result, mode="eval").body
             case _:
                 return description, type_name
 
-    # if get_origin(type) == Annotated:
-    #     for annotation in get_args(type):
-    #         if isinstance(annotation, TypeDescription):
-    #             return annotation.description
-    #     # Strip away annotations
-    #     type = get_args(type)[0]
-    # return getattr(type, "__name__", str(type))
 
-def parse_eval_type(typ: Any) -> tuple[str | None, str]:
+def iter_params_with_defaults(
+    func: ast.FunctionDef,
+) -> Iterable[tuple[ast.arg, ast.expr | None]]:
     """
-    Given an evaluated type signature, returns a tuple of (value description, type signature).
+    Iterates over the parameters of a function definition, yielding each parameter along with its default value.
+    If the parameter has no default value, None is yielded.
     """
-    description: str | None = None
-    type_name: str | None = None
+    for param in func.args.posonlyargs:
+        yield param, None
+    yield from zip_longest(func.args.args, func.args.defaults, fillvalue=None)  # type: ignore
+    if func.args.vararg is not None:
+        yield func.args.vararg, None
+    yield from zip_longest(func.args.kwonlyargs, func.args.kw_defaults, fillvalue=None)  # type: ignore
+    if func.args.kwarg is not None:
+        yield func.args.kwarg, None
 
-    if get_origin(typ) == Annotated:
-        for annotation in get_args(typ):
-            if isinstance(annotation, TypeDescription):
-                type_name = annotation.description
-            elif isinstance(annotation, Description):
-                description = annotation.description
-
-        # Strip away annotations
-        typ = get_args(typ)[0]
-
-    # If the type name wasn't explicitly annotated, use type.__name__
-    return description, type_name or getattr(typ, "__name__", str(typ))
-
-def parse_type(typ: Any) -> tuple[str | None, str]:
-    """
-    Parses a type signature and returns a tuple of (value description, type signature).
-    This function handles both evaluated and unevaluated types.
-    """
-    if isinstance(typ, str):
-        return parse_uneval_type(typ)
-    else:
-        return parse_eval_type(typ)
 
 def docstring_from_signature(func: Callable[..., Any]) -> Docstring:
     """
-    Simulates a Docstring based on the function's signature only.
-    This doesn't use the function's docstring, but rather generates a new one based on the function's parameters and return type.
+    Builds a Docstring object based on the function's signature only.
     """
     doc = Docstring()
 
-    signature = inspect.signature(func)
+    parsed = ast.parse(dedent(inspect.getsource(func)), mode="exec").body[0]
 
-    for param_name, param in signature.parameters.items():
-        # type_name, = extract_typename(param.annotation)
-        param_description, type_name = parse_type(param.annotation)
+    if not isinstance(parsed, ast.FunctionDef):
+        raise ValueError(
+            "func was not a function definition. Perhaps it was a lambda or callable object?"
+        )
+
+    for param, default in iter_params_with_defaults(parsed):
+        param_description, type_name = parse_uneval_type(param.annotation)
         doc.meta.append(
             DocstringParam(
-                arg_name=param_name,
+                arg_name=param.arg,
                 description=param_description,
-                default=None
-                if param.default is inspect.Signature.empty
-                else str(param.default),
+                default=ast.unparse(default) if default is not None else None,
                 type_name=type_name,
-                is_optional=param.default is not inspect.Signature.empty,
-                args=["param", param_name]
+                is_optional=default is not None,
+                args=["param", param.arg],
             )
         )
 
-    ret_description, ret_type = parse_type(signature.return_annotation) if signature.return_annotation is not inspect.Signature.empty else (None, None)
+    ret_description, ret_type = parse_uneval_type(parsed.returns)
     doc.meta.append(
         DocstringReturns(
             type_name=ret_type,

--- a/src/docstrands/signature.py
+++ b/src/docstrands/signature.py
@@ -1,0 +1,140 @@
+"""
+Utilities for extracting type information by inspecting functions rather than parsing docstrings.
+"""
+from __future__ import annotations
+from typing import Callable, Any
+from docstring_parser import Docstring, DocstringParam, DocstringReturns
+from typing import (
+    Annotated,
+    Callable,
+    Any,
+    get_args,
+    get_origin,
+)
+from docstring_parser import (
+    DocstringParam,
+    Docstring,
+    DocstringReturns,
+)
+import inspect
+import ast
+
+from docstrands.annotations import Description, TypeDescription
+
+def extract_description(typ: str) -> str | None:
+    """
+    Extracts the description from a type signature provided as a string.
+    """
+    if get_origin(typ) is Annotated:
+        for annotation in get_args(typ):
+            if isinstance(annotation, Description):
+                return annotation.description
+
+def parse_uneval_type(typ: str) -> tuple[str | None, str]:
+    """
+    Given an unevaluated type signature as a string, returns a tuple of (value description, type signature).
+    This does not evaluate the type, meaning that Python version is not important.
+    """
+    parsed: ast.expr = ast.parse(typ, mode="eval").body
+    description: str | None = None
+    type_name = typ
+    # Peel away any number of Annotated until we reach the inner type
+    while True:
+        match parsed:
+            case ast.Subscript(
+                value=ast.Name(id="Annotated"),
+                slice=ast.Tuple(elts=[parsed, *annotations]),
+            ):
+                # Peel away the Annotated type each iteration
+                type_name: str = ast.unparse(parsed)
+                for annotation in annotations:
+                    # If we find a Description or TypeDescription, we update the return value
+                    compiled = compile(ast.Expression(annotation), filename="<ast>", mode="eval")
+                    result = eval(compiled)
+                    if isinstance(result, Description):
+                        description = result.description
+                    elif isinstance(result, TypeDescription):
+                        type_name = result.description
+            case ast.Constant():
+                # Evaluate types expressed as strings
+                compiled = compile(ast.Expression(parsed), filename="<ast>", mode="eval")
+                result = type_name = eval(compiled)
+                parsed = ast.parse(result, mode="eval").body
+            case _:
+                return description, type_name
+
+    # if get_origin(type) == Annotated:
+    #     for annotation in get_args(type):
+    #         if isinstance(annotation, TypeDescription):
+    #             return annotation.description
+    #     # Strip away annotations
+    #     type = get_args(type)[0]
+    # return getattr(type, "__name__", str(type))
+
+def parse_eval_type(typ: Any) -> tuple[str | None, str]:
+    """
+    Given an evaluated type signature, returns a tuple of (value description, type signature).
+    """
+    description: str | None = None
+    type_name: str | None = None
+
+    if get_origin(typ) == Annotated:
+        for annotation in get_args(typ):
+            if isinstance(annotation, TypeDescription):
+                type_name = annotation.description
+            elif isinstance(annotation, Description):
+                description = annotation.description
+
+        # Strip away annotations
+        typ = get_args(typ)[0]
+
+    # If the type name wasn't explicitly annotated, use type.__name__
+    return description, type_name or getattr(typ, "__name__", str(typ))
+
+def parse_type(typ: Any) -> tuple[str | None, str]:
+    """
+    Parses a type signature and returns a tuple of (value description, type signature).
+    This function handles both evaluated and unevaluated types.
+    """
+    if isinstance(typ, str):
+        return parse_uneval_type(typ)
+    else:
+        return parse_eval_type(typ)
+
+def docstring_from_signature(func: Callable[..., Any]) -> Docstring:
+    """
+    Simulates a Docstring based on the function's signature only.
+    This doesn't use the function's docstring, but rather generates a new one based on the function's parameters and return type.
+    """
+    doc = Docstring()
+
+    signature = inspect.signature(func)
+
+    for param_name, param in signature.parameters.items():
+        # type_name, = extract_typename(param.annotation)
+        param_description, type_name = parse_type(param.annotation)
+        doc.meta.append(
+            DocstringParam(
+                arg_name=param_name,
+                description=param_description,
+                default=None
+                if param.default is inspect.Signature.empty
+                else str(param.default),
+                type_name=type_name,
+                is_optional=param.default is not inspect.Signature.empty,
+                args=["param", param_name]
+            )
+        )
+
+    ret_description, ret_type = parse_type(signature.return_annotation) if signature.return_annotation is not inspect.Signature.empty else (None, None)
+    doc.meta.append(
+        DocstringReturns(
+            type_name=ret_type,
+            description=ret_description,
+            is_generator=inspect.isgeneratorfunction(func),
+            return_name=None,
+            args=[],
+        )
+    )
+
+    return doc

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 from typing import Annotated, Type
-from docstrands import Description, docstring
-from tests.utils import DocTester, each_tester
-import pytest
-import sys
+from docstrands import Description, docstring, TypeDescription
+from tests.utils import DocTester, each_tester, at_least_310
 
-
+@at_least_310
 @each_tester
-def test_annotations(Tester: Type[DocTester]):
-
-    if sys.version_info < (3, 10, 0):
-        pytest.skip("Skipping on Python 3.9 and below since it cannot evaluate union syntax")
+def test_description(Tester: Type[DocTester]):
 
     @docstring(style="google", use_annotations=True)
     def add(
@@ -27,3 +22,16 @@ def test_annotations(Tester: Type[DocTester]):
     assert tester.has_parameter("c", "An int or float parameter.", "int | float")
     assert tester.has_parameter("d", "String union.", "int | None")
     assert tester.has_returns("The return value.")
+
+@at_least_310
+@each_tester
+def test_type_description(Tester: Type[DocTester]):
+
+    @docstring(style="google", use_annotations=True)
+    def add(
+        a: Annotated[int | list[int], TypeDescription("An int or list thereof.")],
+    ):
+        ...
+
+    tester = Tester(add, "google")
+    assert tester.has_parameter("a", "", "An int or list thereof.")

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,3 +1,5 @@
+# These tests also check that actual docstrings are not needed 
+# And that the docstring decorator works with annotations only
 from __future__ import annotations
 from typing import Annotated, Type
 from docstrands import Description, docstring, TypeDescription

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,22 +1,21 @@
-# These tests also check that actual docstrings are not needed 
+# These tests also check that actual docstrings are not needed
 # And that the docstring decorator works with annotations only
 from __future__ import annotations
 from typing import Annotated, Type
 from docstrands import Description, docstring, TypeDescription
 from tests.utils import DocTester, each_tester, at_least_310
 
+
 @at_least_310
 @each_tester
 def test_description(Tester: Type[DocTester]):
-
     @docstring(style="google", use_annotations=True)
     def add(
         a: Annotated[int, Description("An int parameter.")],
         b: Annotated[Annotated[float, Description("A float parameter.")], "foo"],
         c: Annotated[int | float, Description("An int or float parameter.")],
-        d: "Annotated[int | None, Description('String union.')]"
-    ) -> Annotated[str, Description("The return value.")]:
-        ...
+        d: "Annotated[int | None, Description('String union.')]",
+    ) -> Annotated[str, Description("The return value.")]: ...
 
     tester = Tester(add, "google")
     assert tester.has_parameter("a", "An int parameter.", "int")
@@ -25,15 +24,14 @@ def test_description(Tester: Type[DocTester]):
     assert tester.has_parameter("d", "String union.", "int | None")
     assert tester.has_returns("The return value.")
 
+
 @at_least_310
 @each_tester
 def test_type_description(Tester: Type[DocTester]):
-
     @docstring(style="google", use_annotations=True)
     def add(
         a: Annotated[int | list[int], TypeDescription("An int or list thereof.")],
-    ):
-        ...
+    ): ...
 
     tester = Tester(add, "google")
     assert tester.has_parameter("a", "", "An int or list thereof.")

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 from typing import Annotated, Type
 from docstrands import Description, docstring, TypeDescription
-from tests.utils import DocTester, each_tester, at_least_310
+from tests.utils import DocTester, each_tester
 
 
-@at_least_310
 @each_tester
 def test_description(Tester: Type[DocTester]):
     @docstring(style="google", use_annotations=True)
@@ -25,7 +24,6 @@ def test_description(Tester: Type[DocTester]):
     assert tester.has_returns("The return value.")
 
 
-@at_least_310
 @each_tester
 def test_type_description(Tester: Type[DocTester]):
     @docstring(style="google", use_annotations=True)

--- a/tests/test_epytext.py
+++ b/tests/test_epytext.py
@@ -1,5 +1,6 @@
 from docstrands.parsed_func import docstring
 
+
 @docstring(style="epydoc")
 def source(a: int, b: int, *, c: bool) -> None:
     """
@@ -14,6 +15,7 @@ def source(a: int, b: int, *, c: bool) -> None:
     @return: The result
     """
 
+
 @source.copy_params("a", "b", "c")
 @source.copy_returns()
 @source.copy_description()
@@ -21,6 +23,7 @@ def source(a: int, b: int, *, c: bool) -> None:
 @docstring(style="epydoc")
 def dest(a: int, b: int, *, c: bool) -> None:
     pass
+
 
 def test_description():
     assert set(source.__doc__.split("\n")) == set(dest.__doc__.split("\n"))

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,10 +1,8 @@
 from docstrands.signature import parse_uneval_type
-from tests.utils import at_least_310
 import pytest
 import ast
 
 
-@at_least_310
 @pytest.mark.parametrize(
     "signature, expected_descr, expected_type",
     [

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,15 +1,29 @@
-from typing import Annotated, Optional
-from docstrands.signature import parse_type
-from docstrands import Description, TypeDescription
+from docstrands.signature import parse_uneval_type
 from tests.utils import at_least_310
+import pytest
+import ast
+
 
 @at_least_310
-def test_extract_typename():
-    assert parse_type(float) == (None, "float")
-    assert parse_type("float") == (None, "float")
-    assert parse_type(None) == (None, "None")
-    assert parse_type(str | int) == (None, "str | int")
-    assert parse_type(Optional["int"]) == (None, "Optional[int]")
-    assert parse_type(Annotated[int, "foo"]) == (None, "int")
-    assert parse_type(Annotated[int, Description("foo")]) == ("foo", "int")
-    assert parse_type(Annotated[int, TypeDescription("foo")]) == (None, "foo")
+@pytest.mark.parametrize(
+    "signature, expected_descr, expected_type",
+    [
+        ("float", None, "float"),
+        ("'float'", None, "float"),
+        ("None", None, "None"),
+        ("str | int", None, "str | int"),
+        ("Optional[int]", None, "Optional[int]"),
+        ("Annotated[int, 'foo']", None, "int"),
+        ("Annotated[int, Description('foo')]", "foo", "int"),
+        ("Annotated[int, TypeDescription('foo')]", None, "foo"),
+    ],
+)
+def test_extract_typename(
+    signature: str, expected_descr: str | None, expected_type: str | None
+):
+    """
+    Test that parse_uneval_type correctly extracts the description and type from an ast.expr
+    that represents a type signature.
+    """
+    expr = ast.parse(signature, mode="eval").body
+    assert parse_uneval_type(expr) == (expected_descr, expected_type)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -14,6 +14,7 @@ import ast
         ("Annotated[int, 'foo']", None, "int"),
         ("Annotated[int, Description('foo')]", "foo", "int"),
         ("Annotated[int, TypeDescription('foo')]", None, "foo"),
+        ("Annotated[int, TypeDescription('foo'), Description('bar')]", "bar", "foo"),
     ],
 )
 def test_extract_typename(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,13 +1,15 @@
-from typing import Annotated
-from docstrands.parsed_func import extract_typename
+from typing import Annotated, Optional
+from docstrands.signature import parse_type
 from docstrands import Description, TypeDescription
 from tests.utils import at_least_310
 
 @at_least_310
 def test_extract_typename():
-    assert extract_typename(float) == "float"
-    assert extract_typename(None) == "None"
-    assert extract_typename(str | int) == "str | int"
-    assert extract_typename(Annotated[int, "foo"]) == "int"
-    assert extract_typename(Annotated[int, Description("foo")]) == "int"
-    assert extract_typename(Annotated[int, TypeDescription("foo")]) == "foo"
+    assert parse_type(float) == (None, "float")
+    assert parse_type("float") == (None, "float")
+    assert parse_type(None) == (None, "None")
+    assert parse_type(str | int) == (None, "str | int")
+    assert parse_type(Optional["int"]) == (None, "Optional[int]")
+    assert parse_type(Annotated[int, "foo"]) == (None, "int")
+    assert parse_type(Annotated[int, Description("foo")]) == ("foo", "int")
+    assert parse_type(Annotated[int, TypeDescription("foo")]) == (None, "foo")

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,13 @@
+from typing import Annotated
+from docstrands.parsed_func import extract_typename
+from docstrands import Description, TypeDescription
+from tests.utils import at_least_310
+
+@at_least_310
+def test_extract_typename():
+    assert extract_typename(float) == "float"
+    assert extract_typename(None) == "None"
+    assert extract_typename(str | int) == "str | int"
+    assert extract_typename(Annotated[int, "foo"]) == "int"
+    assert extract_typename(Annotated[int, Description("foo")]) == "int"
+    assert extract_typename(Annotated[int, TypeDescription("foo")]) == "foo"

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -2,6 +2,7 @@ from typing import Type
 from docstrands.parsed_func import docstring
 from tests.utils import each_tester, DocTester
 
+
 @docstring(style="google")
 def divide(a: int, b: int, *, floor: bool) -> float:
     """Divide two numbers.
@@ -15,6 +16,7 @@ def divide(a: int, b: int, *, floor: bool) -> float:
         The result of the division.
     """
     return a // b if floor else a / b
+
 
 @docstring(style="google")
 def source(a: int, b: int, *, c: bool) -> None:
@@ -33,6 +35,7 @@ def source(a: int, b: int, *, c: bool) -> None:
         The result
     """
 
+
 @source.copy_params("a", "b")
 @docstring(style="google")
 def param_dest(a: int, b: int, d: float):
@@ -44,6 +47,7 @@ def param_dest(a: int, b: int, d: float):
     """
     pass
 
+
 @source.copy_returns()
 @docstring(style="google")
 def return_dest(a: int, b: int):
@@ -52,10 +56,12 @@ def return_dest(a: int, b: int):
     """
     pass
 
+
 @source.copy_synopsis()
 @docstring(style="google")
 def synopsis_dest(a: int, b: int):
     pass
+
 
 @source.copy_description()
 @docstring(style="google")
@@ -63,6 +69,7 @@ def description_dest(a: int, b: int):
     """
     A synopsis only
     """
+
 
 @each_tester
 def test_params(Tester: Type[DocTester]):
@@ -72,27 +79,38 @@ def test_params(Tester: Type[DocTester]):
     assert not tester.has_parameter("c")
     assert tester.has_parameter("d", "A unique parameter")
 
+
 @each_tester
 def test_return(Tester: Type[DocTester]):
     tester = Tester(return_dest, "google")
-    assert tester.has_synopsis("Some other description"), "Synopsis should be unaffected"
+    assert tester.has_synopsis("Some other description"), (
+        "Synopsis should be unaffected"
+    )
     assert tester.has_returns("The result"), "Return documentation should be copied"
+
 
 @each_tester
 def test_synopsis(Tester: Type[DocTester]):
     tester = Tester(synopsis_dest, "google")
     assert tester.has_synopsis("Some description."), "Synopsis should be copied"
 
+
 @each_tester
 def test_description(Tester: Type[DocTester]):
     tester = Tester(description_dest, "google")
     assert tester.has_synopsis("A synopsis only"), "Synopsis should not be affected"
-    assert tester.has_description("Some more detail about the function.\nThis has several lines."), "Synopsis should not be affected"
+    assert tester.has_description(
+        "Some more detail about the function.\nThis has several lines."
+    ), "Synopsis should not be affected"
+
 
 @each_tester
 def test_no_docstring(Tester: Type[DocTester]):
     @docstring(style="google")
-    def no_docstring(a: int): pass
+    def no_docstring(a: int):
+        pass
 
     tester = Tester(no_docstring, "google")
-    assert tester.has_parameter("a", type="int"), "Even functions with no user-provided docstring should gain a skeleton docstring"
+    assert tester.has_parameter("a", type="int"), (
+        "Even functions with no user-provided docstring should gain a skeleton docstring"
+    )

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -88,3 +88,11 @@ def test_description(Tester: Type[DocTester]):
     tester = Tester(description_dest, "google")
     assert tester.has_synopsis("A synopsis only"), "Synopsis should not be affected"
     assert tester.has_description("Some more detail about the function.\nThis has several lines."), "Synopsis should not be affected"
+
+@each_tester
+def test_no_docstring(Tester: Type[DocTester]):
+    @docstring(style="google")
+    def no_docstring(a: int): pass
+
+    tester = Tester(no_docstring, "google")
+    assert tester.has_parameter("a", type="int"), "Even functions with no user-provided docstring should gain a skeleton docstring"

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,0 +1,29 @@
+
+from docstrands.parsed_func import docstring
+
+@docstring(style="rest")
+def source(a: int, b: int, *, c: bool) -> None:
+    """
+    Some description.
+
+    Some more detail about the function.
+    This has several lines.
+
+    Parameters
+    ----------
+    a : Positional argument a
+    :param b: Positional argument b
+    :param c: Keyword-only argument c
+    :returns: The result
+    """
+
+@source.copy_params("a", "b", "c")
+@source.copy_returns()
+@source.copy_description()
+@source.copy_synopsis()
+@docstring(style="rest")
+def dest(a: int, b: int, *, c: bool) -> None:
+    pass
+
+def test_description():
+    assert set(source.__doc__.split("\n")) == set(dest.__doc__.split("\n"))

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,5 +1,5 @@
-
 from docstrands.parsed_func import docstring
+
 
 @docstring(style="rest")
 def source(a: int, b: int, *, c: bool) -> None:
@@ -17,6 +17,7 @@ def source(a: int, b: int, *, c: bool) -> None:
     :returns: The result
     """
 
+
 @source.copy_params("a", "b", "c")
 @source.copy_returns()
 @source.copy_description()
@@ -24,6 +25,7 @@ def source(a: int, b: int, *, c: bool) -> None:
 @docstring(style="rest")
 def dest(a: int, b: int, *, c: bool) -> None:
     pass
+
 
 def test_description():
     assert set(source.__doc__.split("\n")) == set(dest.__doc__.split("\n"))

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -35,3 +35,14 @@ def test_signature():
     assert doc.returns.type_name == "nothing"
     assert doc.returns.is_generator is False
     assert doc.returns.return_name is None
+
+def test_no_return():
+    """
+    Tests that a function with no return type annotation will not get a returns section.
+    """
+    def example(
+        a: Annotated[int, TypeDescription("integer")],
+    ): pass
+
+    doc = docstring_from_signature(example)
+    assert doc.returns is None

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,15 +1,22 @@
-from typing import Annotated
+from typing import Annotated, Any
 from docstrands.signature import docstring_from_signature
 from docstrands.annotations import Description, TypeDescription
+
 
 def test_signature():
     # Tests docstring_from_signature
     def example(
-            a: Annotated[int, TypeDescription("integer")],
-            b: Annotated[float | str, Description("This configures xyz")] = 1.0
-        ) -> Annotated[None, Description("Don't use this"), TypeDescription("nothing")]: pass
+        a: Annotated[int, TypeDescription("integer")],
+        /,
+        b: Annotated[float | str, Description("This configures xyz")] = 1.0,
+        *,
+        c: bool = True,
+        **kwargs: Any,
+    ) -> Annotated[None, Description("Don't use this"), TypeDescription("nothing")]:
+        pass
+
     doc = docstring_from_signature(example)
-    assert len(doc.params) == 2
+    assert len(doc.params) == 4
     assert doc.params[0].arg_name == "a"
     assert doc.params[0].type_name == "integer"
     assert doc.params[0].description is None

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,0 +1,30 @@
+from typing import Annotated
+from docstrands.signature import docstring_from_signature
+from docstrands.annotations import Description, TypeDescription
+
+def test_signature():
+    # Tests docstring_from_signature
+    def example(
+            a: Annotated[int, TypeDescription("integer")],
+            b: Annotated[float | str, Description("This configures xyz")] = 1.0
+        ) -> Annotated[None, Description("Don't use this"), TypeDescription("nothing")]: pass
+    doc = docstring_from_signature(example)
+    assert len(doc.params) == 2
+    assert doc.params[0].arg_name == "a"
+    assert doc.params[0].type_name == "integer"
+    assert doc.params[0].description is None
+    assert doc.params[0].default is None
+    assert doc.params[0].is_optional is False
+
+    assert doc.params[1].arg_name == "b"
+    assert doc.params[1].type_name == "float | str"
+    assert doc.params[1].description == "This configures xyz"
+    assert doc.params[1].default == "1.0"
+    assert doc.params[1].is_optional is True
+
+    assert doc.returns is not None
+    assert doc.returns.args == []
+    assert doc.returns.description == "Don't use this"
+    assert doc.returns.type_name == "nothing"
+    assert doc.returns.is_generator is False
+    assert doc.returns.return_name is None

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,5 +1,6 @@
 from docstrands.parsed_func import docstring
 
+
 @docstring(style="rest")
 def source(a: int, b: int, *, c: bool) -> None:
     """
@@ -14,6 +15,7 @@ def source(a: int, b: int, *, c: bool) -> None:
     :returns: The result
     """
 
+
 @source.copy_params("a", "b", "c")
 @source.copy_returns()
 @source.copy_description()
@@ -21,6 +23,7 @@ def source(a: int, b: int, *, c: bool) -> None:
 @docstring(style="rest")
 def dest(a: int, b: int, *, c: bool) -> None:
     pass
+
 
 def test_description():
     assert set(source.__doc__.split("\n")) == set(dest.__doc__.split("\n"))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,13 +13,17 @@ import griffe
 GRIFFE_STYLE_MAP: dict[DocstringStyle, griffe.DocstringStyle] = {
     "google": "google",
     "numpydoc": "numpy",
-    "rest": "sphinx"
+    "rest": "sphinx",
 }
 
-at_least_310 = pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
+at_least_310 = pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="requires python3.10 or higher"
+)
+
 
 def strip_whitespace(string: str) -> str:
     return string.replace("\n", "").replace(" ", "")
+
 
 class DocstringTester(ABC):
     style: DocstringStyle
@@ -28,7 +32,9 @@ class DocstringTester(ABC):
         self.style = style
 
     @abstractmethod
-    def has_parameter(self, name: str, description: str | None = None, type: str | None = None) -> bool:
+    def has_parameter(
+        self, name: str, description: str | None = None, type: str | None = None
+    ) -> bool:
         """
         Checks if the docstring has a parameter with the given name and (optionally) description and type.
         """
@@ -55,6 +61,7 @@ class DocstringTester(ABC):
         """
         pass
 
+
 class StringTesterMixin:
     # Note: currently assumes that all docstrings are Google style
     doc: str
@@ -65,7 +72,9 @@ class StringTesterMixin:
         """
         return re.search(f"\\b{text}\\b", self.doc) is not None
 
-    def has_parameter(self, name: str, description: str | None = None, type: str | None = None) -> bool:
+    def has_parameter(
+        self, name: str, description: str | None = None, type: str | None = None
+    ) -> bool:
         # These tests are a bit loose, but the other tester subclasses do a more precise job
         if description is not None and description not in self.doc:
             # Missing param description
@@ -75,9 +84,13 @@ class StringTesterMixin:
             return False
         # Only use the word boundary test for the parameter name, since e.g. `"a" in self.doc` is very likely to return True
         return self._doc_bounded_contains(name)
-    
+
     def has_returns(self, returns: str, type: str | None = None) -> bool:
-        return "Returns" in self.doc and returns in self.doc and (type is None or type in self.doc)
+        return (
+            "Returns" in self.doc
+            and returns in self.doc
+            and (type is None or type in self.doc)
+        )
 
     def has_synopsis(self, synopsis: str) -> bool:
         return synopsis in self.doc
@@ -90,10 +103,12 @@ class StringTesterMixin:
                 return False
         return True
 
+
 class DocTester(StringTesterMixin, DocstringTester):
     """
     Tests docstrings directly via the __doc__ attribute.
     """
+
     def __init__(self, obj: object, style: DocstringStyle) -> None:
         if obj.__doc__ is None:
             raise ValueError("Object has no docstring.")
@@ -105,6 +120,7 @@ class HelpTester(StringTesterMixin, DocstringTester):
     """
     Tests docstrings via the built-in help() function.
     """
+
     def __init__(self, obj: object, style: DocstringStyle) -> None:
         output = StringIO()
         helper = Helper(output=output)
@@ -112,38 +128,51 @@ class HelpTester(StringTesterMixin, DocstringTester):
         self.doc = output.getvalue()
         super().__init__(obj, style)
 
+
 class DocstringParserTester(DocstringTester):
     """
     Tests docstrings via the docstring_parser module.
     """
+
     doc: docstring_parser.Docstring
 
     def __init__(self, obj: object, style: DocstringStyle) -> None:
         self.doc = docstring_parser.parse_from_object(obj, style=STYLE_MAP[style])
         super().__init__(obj, style)
 
-    def has_parameter(self, name: str, description: str | None = None, type: str | None = None) -> bool:
+    def has_parameter(
+        self, name: str, description: str | None = None, type: str | None = None
+    ) -> bool:
         for param in self.doc.params:
             if param.arg_name == name:
-                return all([
-                    description is None or param.description == description,
-                    type is None or param.type_name == type
-                ])
+                return all(
+                    [
+                        description is None or param.description == description,
+                        type is None or param.type_name == type,
+                    ]
+                )
         return False
 
     def has_returns(self, returns: str, type: str | None = None) -> bool:
-        return self.doc.returns is not None and self.doc.returns.description is not None and returns in self.doc.returns.description and (type is None or self.doc.returns.type_name == type)
-    
+        return (
+            self.doc.returns is not None
+            and self.doc.returns.description is not None
+            and returns in self.doc.returns.description
+            and (type is None or self.doc.returns.type_name == type)
+        )
+
     def has_synopsis(self, synopsis: str) -> bool:
         return self.doc.short_description == synopsis
 
     def has_description(self, description: str) -> bool:
         return self.doc.long_description == description
 
+
 class GriffeTester(DocstringTester):
     """
     Uses the Griffe library to parse and test docstrings
     """
+
     doc: griffe.Docstring
 
     def __init__(self, obj: object, style: DocstringStyle):
@@ -152,22 +181,28 @@ class GriffeTester(DocstringTester):
         self.doc = griffe.Docstring(obj.__doc__, parser=GRIFFE_STYLE_MAP[style])
         super().__init__(obj, style)
 
-    def has_parameter(self, name: str, description: str | None = None, type: str | None = None) -> bool:
+    def has_parameter(
+        self, name: str, description: str | None = None, type: str | None = None
+    ) -> bool:
         for section in self.doc.parsed:
             if isinstance(section, griffe.DocstringSectionParameters):
                 for param in section.value:
                     if param.name == name:
-                        return all([
-                            description is None or param.description == description,
-                            type is None or param.annotation == type
-                        ])
+                        return all(
+                            [
+                                description is None or param.description == description,
+                                type is None or param.annotation == type,
+                            ]
+                        )
         return False
 
     def has_returns(self, returns: str, type: str | None = None) -> bool:
         for section in self.doc.parsed:
             if isinstance(section, griffe.DocstringSectionReturns):
                 for line in section.value:
-                    return line.description == returns and (type is None or line.value == type)
+                    return line.description == returns and (
+                        type is None or line.value == type
+                    )
         return False
 
     def has_synopsis(self, synopsis: str) -> bool:
@@ -175,13 +210,15 @@ class GriffeTester(DocstringTester):
             if isinstance(section, griffe.DocstringSectionText):
                 # Griffe does not separate the synopsis from the description
                 return synopsis in section.value
-        return False    
+        return False
 
     def has_description(self, description: str) -> bool:
         for section in self.doc.parsed:
             if isinstance(section, griffe.DocstringSectionText):
                 return description in section.value
         return False
-        
 
-each_tester = pytest.mark.parametrize("Tester", [DocTester, HelpTester, DocstringParserTester, GriffeTester])
+
+each_tester = pytest.mark.parametrize(
+    "Tester", [DocTester, HelpTester, DocstringParserTester, GriffeTester]
+)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -59,7 +59,7 @@ class StringTesterMixin:
     # Note: currently assumes that all docstrings are Google style
     doc: str
 
-    def _doc_contains(self, text: str) -> bool:
+    def _doc_bounded_contains(self, text: str) -> bool:
         """
         Checks if a given string is contained within the docstring, with \\b boundary delimiters
         """
@@ -74,7 +74,7 @@ class StringTesterMixin:
             # Missing type description
             return False
         # Only use the word boundary test for the parameter name, since e.g. `"a" in self.doc` is very likely to return True
-        return self._doc_contains(name)
+        return self._doc_bounded_contains(name)
     
     def has_returns(self, returns: str, type: str | None = None) -> bool:
         return "Returns" in self.doc and returns in self.doc and (type is None or type in self.doc)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from io import StringIO
 from pydoc import Helper
-import sys
 import re
 
 import docstring_parser
@@ -15,10 +14,6 @@ GRIFFE_STYLE_MAP: dict[DocstringStyle, griffe.DocstringStyle] = {
     "numpydoc": "numpy",
     "rest": "sphinx",
 }
-
-at_least_310 = pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="requires python3.10 or higher"
-)
 
 
 def strip_whitespace(string: str) -> str:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from io import StringIO
 from pydoc import Helper
+import sys
+import re
 
 import docstring_parser
 from docstrands.parsed_func import DocstringStyle, STYLE_MAP
@@ -13,6 +15,8 @@ GRIFFE_STYLE_MAP: dict[DocstringStyle, griffe.DocstringStyle] = {
     "numpydoc": "numpy",
     "rest": "sphinx"
 }
+
+at_least_310 = pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 
 def strip_whitespace(string: str) -> str:
     return string.replace("\n", "").replace(" ", "")
@@ -55,13 +59,22 @@ class StringTesterMixin:
     # Note: currently assumes that all docstrings are Google style
     doc: str
 
+    def _doc_contains(self, text: str) -> bool:
+        """
+        Checks if a given string is contained within the docstring, with \\b boundary delimiters
+        """
+        return re.search(f"\\b{text}\\b", self.doc) is not None
+
     def has_parameter(self, name: str, description: str | None = None, type: str | None = None) -> bool:
-        if description is None:
-            return f"    {name}:" in self.doc
-        elif type is None:
-            return f"    {name}: {description}" in self.doc
-        else:
-            return f"    {name} ({type}): {description}" in self.doc
+        # These tests are a bit loose, but the other tester subclasses do a more precise job
+        if description is not None and description not in self.doc:
+            # Missing param description
+            return False
+        if type is not None and type not in self.doc:
+            # Missing type description
+            return False
+        # Only use the word boundary test for the parameter name, since e.g. `"a" in self.doc` is very likely to return True
+        return self._doc_contains(name)
     
     def has_returns(self, returns: str, type: str | None = None) -> bool:
         return "Returns" in self.doc and returns in self.doc and (type is None or type in self.doc)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -140,11 +140,9 @@ class DocstringParserTester(DocstringTester):
     ) -> bool:
         for param in self.doc.params:
             if param.arg_name == name:
-                return all(
-                    [
-                        description is None or param.description == description,
-                        type is None or param.type_name == type,
-                    ]
+                return (
+                    (description is None or param.description == description) and
+                    (type is None or param.type_name == type)
                 )
         return False
 


### PR DESCRIPTION
Allow re-defining the type description via annotation. Closes #5.

e.g. 

```python
from docstrands import docstring, TypeDescription
from typing import Annotated

@docstring(style="google", use_annotations=True)
def add(
    a: Annotated[int | list[int], TypeDescription("An int or list thereof.")],
):
    ...

help(add)
```
Will show:
```
<function add>
    Args:
        a (An int or list thereof.):
```

*** 

Actually I discovered that my first attempt did a bad job at handling functions that had no actual docstring, so I ended up doing a large rewrite to support functions that are "documented" using their type signature only.

`docstrands` does this by analysing the function's source code and not by evaluating the type signature, which means it will preserve the style the user chose, and will also meaning that your can use Python syntax that your interpreter doesn't necessarily support, like `int | float`. Then this is automatically merged with the user-defined signature. 

I also incidentally dropped support for Python 3.9. It's EOL in a few months and it's a real pain to work with. No `|` type union syntax, and no `match` which really simplifies some of this code.